### PR TITLE
Peer review for doc-improvement-27

### DIFF
--- a/docs/concepts/packaging-types.adoc
+++ b/docs/concepts/packaging-types.adoc
@@ -1,51 +1,55 @@
 [#packaging_types]
 = Packaging Types (Uberjars & Hollow Jars)
 
-When using WildFly Swarm, you have two different ways to package your
+When using WildFly Swarm, there are two different ways to package your
 runtime and application, depending on how you intend to use and deploy
 it.
 
 [#uberjar]
-## Uberjar
+== Uberjar
 
-An _uberjar_ is a single Java `.jar` file that includes everything that
-is required to execute your application.  This includes both the selected
-runtime components (the parts you may consider to be the _app server_)
-along with the application compoments (you `.war`).
+An _uberjar_ is a single Java `.jar` file that includes everything you need
+to execute your application. This means both the runtime components
+you have selected--you can understand that to as the app server-- along with
+the application components (your `.war` file).
 
-An uberjar is useful for many continuous-integration/continuous-deployment (CI/CD)
-pipeline styles, in which a single runnable binary artifact is produced 
-and moved through your organization's testing, validation and production
-environments.
+An uberjar is useful for many continuous integration and continuous deployment
+(CI/CD) pipeline styles, in which a single executable binary artifact is produced
+and moved through the testing, validation, and production environments in your
+organization.
 
-The uberjars produced by WildFly Swarm include the name of your application,
-along with the suffix of `-swarm.jar`.
+The names of the uberjars that WildFly Swarm produces include the name of your
+application and the `-swarm.jar` suffix.
 
-An uberjar can be executed as any executable JAR:
+An uberjar can be executed like any executable JAR:
 
-    $ java -jar myapp-swarm.jar
+[source]
+----
+$ java -jar myapp-swarm.jar
+----
 
-[#hollow_jar]
-## Hollow Jar
+[#hollow-jar]
+== Hollow JAR
 
-A _hollow jar_ is similar to the _uberjar_ above, but includes _only_
-the runtime components, and does _not_ include your application code.
-When using a hollow jar, you must provide the application `.war` file
-as an argument on the command-line when executing.
+A _hollow JAR_ is similar to an uberjar, but includes only
+the runtime components, and does not include your application code.
 
-A hollow jar works well for deployment processes that involve Linux
-containers such as Docker. When using containers, you may wish to place
-the runtime components on a lower container image which remains more
-consistent, while allowing quicker rebuilds of the higher layer which
-contains only your application code.
+A hollow jar is suitable for deployment processes that involve Linux
+containers such as Docker. When using containers,  place the runtime components
+in a container image lower in the image hierarchy--which means it changes less
+often--so that the higher layer which contains only your application code can
+be rebuilt more quickly.
 
-The hollow jars produced by WildFly Swarm include the name of the
-application, along with the suffix of `-hollowswarm.jar`. You must
-retain your `.war` application separately in order to benefit from
-the hollow jar.
+The names of the hollow JARs that WildFly Swarm produces include the name of
+your application, and the `-hollowswarm.jar` suffix. You must package the
+`.war` file of your application separately in order to benefit from the hollow
+JAR.
 
-To execute a hollow jar with your application, simply pass the path
-to your `.war` on the commandline:
+Provide the application `.war` file as an argument to the Java binary when
+executing the hollow JAR:
 
-    $ java -jar myapp-hollowswarm.jar myapp.war
+[source]
+----
+$ java -jar myapp-hollowswarm.jar myapp.war
+----
 

--- a/docs/howto/create-a-datasource/auto-detecting-jdbc-drivers.adoc
+++ b/docs/howto/create-a-datasource/auto-detecting-jdbc-drivers.adoc
@@ -1,0 +1,36 @@
+[#auto-detecting-jdbc-drivers]
+= Auto-detecting JDBC drivers
+
+WildFly Swarm has the capability to detect, install, and register
+a variety of JDBC drivers based on their inclusion as a dependency
+to your application.
+
+The drivers that WildFly Swarm auto-detects include:
+
+* H2
+* MySQL
+* PostgreSQL
+* EnterpriseDB
+* SQLServer
+* Oracle
+* Sybase
+* DB2
+
+.Prerequisites
+
+* A Maven-based application.
+* A database to connect to.
+* The Maven coordinates of the JDBC driver you want to use.
+
+.Procedure
+
+. Add the appropriate dependency (with the default `<scope>compile</scope>`
+scope) to your application:
++
+[source,xml]
+----
+<dependencies>
+include::pom.xml[tag=dependencies,indent=2]
+</dependencies>
+----
+

--- a/docs/howto/create-a-datasource/configuring-a-datasource.adoc
+++ b/docs/howto/create-a-datasource/configuring-a-datasource.adoc
@@ -1,0 +1,22 @@
+
+[#configuring-a-datasource]
+= Configuring a datasource
+
+.Prerequisites
+
+* A Maven-based application.
+* A JDBC Driver configured.
+
+.Procedure
+. Edit the `project-defaults.yml` file to configure one or more datasources
+using the JDBC driver of your choice. The configuration is stored under `swarm`
+-> `datasources` -> `data-sources`:
++
+[source,yaml]
+----
+swarm:
+  datasources:
+    data-sources:
+include::src/main/resources/project-defaults.yml[tag=datasource,indent=6]
+----
+

--- a/docs/howto/create-a-datasource/configuring-the-jdbc-driver-manually.adoc
+++ b/docs/howto/create-a-datasource/configuring-the-jdbc-driver-manually.adoc
@@ -1,0 +1,23 @@
+[#configuring-the-jdbc-driver-manually]
+= Configuring the JDBC driver manually
+
+.Prerequisites
+
+* A Maven-based application.
+* The `module.xml` file created according to relevant WildFly instructions.
+  This file is necessary to expose the driver through JBoss Modules.
+
+.Procedure
+. Edit the `project-defaults.yml` file to define the driver information.
++
+In the `swarm` -> `datasources` -> `jdbc-drivers` tree, define the driver by
+key, which will be used later for connecting it to the datasource.
++
+[source,yaml]
+----
+swarm:
+  datasources:
+    jdbc-drivers:
+include::src/main/resources/project-defaults.yml[tag=driver,indent=6]
+----
+

--- a/docs/howto/create-a-datasource/index.adoc
+++ b/docs/howto/create-a-datasource/index.adoc
@@ -1,95 +1,34 @@
-[#create_a_datasource]
-= How to create a datasource
+[#creating-a-datasource]
+= Creating a datasource
 
-When working with Java applications, a datasource has
+When working with Java applications, a _datasource_ has
 two components, both equally important:
 
-. JDBC Driver
-. Datasource Definition
+* The JDBC driver
+* The datasource definition
 
-The JDBC driver is responsible to knowing how to communicate
-with the database, while providing a constant API to application
-developers. An application must bring their own JDBC driver,
-since the range of available databases and versions of each driver
-is rather large.  Usually the application will not directly interact
-with the JDBC driver.  Instead, the underlying runtime will manage
-creating a _datasource_ which provides an efficient way to share
-and manage a discrete connection (or pool of connections) to a
-particular database using the driver.
+The task of the JDBC driver is communicating with the database while providing
+a constant API to application developers. An application must supply its own
+JDBC driver because of the wide range of available databases and the driver
+version. Usually, the application does not directly interact with the JDBC
+driver; instead, the underlying runtime manages creating a datasource,
+which provides an efficient way to share and manage a discrete connection or
+a pool of connections to a particular database using the driver.
 
-## JDBC Drivers
+== Configuring a JDBC Driver
 
-### Auto-detection
+There are two options how to configure JDBC drivers:
 
-WildFly Swarm has the capability to detect, install and register
-a variety of JDBC drivers based on their inclusion as a dependency
-to your application.
+include::auto-detecting-jdbc-drivers.adoc[leveloffset=+2]
 
-The currently detectable drivers include:
+include::configuring-the-jdbc-driver-manually.adoc[leveloffset=+2]
 
-* H2
-* MySQL
-* PostgreSQL
-* EnterpriseDB
-* SQLServer
-* Oracle
-* Sybase
-* DB2
+include::configuring-a-datasource.adoc[leveloffset=+1]
 
-.Prerequisites
+== Example full project-defaults.yml file
 
-* A _Maven_-based project
-* A database you wish to connect to
-* The Maven coordinates of the JDBC driver you wish to use
-
-.Procedure
-
-. Add the appropriate dependency (with the default `<scope>compile</scope>`
-scope) to your application:
-+
-[source,xml]
-----
-<dependencies>
-include::pom.xml[tag=dependencies,indent=2]
-</dependencies>
-----
-
-. Optionally configured the JDBC driver
-+
-In the event you need to provide customized driver configuration instead
-of relying on the auto-detection, you can use `project-defaults.yml` to define
-the driver information.  This presumes you've followed the normal WildFly
-instructions for creating an appropriate `module.xml` to expose the 
-driver through _JBoss Modules_.  This is completely unnecessary if you
-rely upon the auto-detection mentioned above.
-+
-Underneath the tree of `swarm` -> `datasources` -> `jdbc-drivers`, you
-can define the driver by key, which will be used later for connecting it
-to a datasource.  
-+
-[source,yaml]
-----
-swarm:
-  datasources:
-    jdbc-drivers:
-include::src/main/resources/project-defaults.yml[tag=driver,indent=6]
-----
-
-. Configure a Datasource
-+
-Once a driver has been configured, through either auto-detection or
-explicit configuration, you can use `project-defaults.yml` to configure
-one or more datasources using that driver, under `swarm` -> `datasources` -> `data-sources`:
-+
-[source,yaml]
-----
-swarm:
-  datasources:
-    data-sources:
-include::src/main/resources/project-defaults.yml[tag=datasource,indent=6]
-----
-
-## Full `project-defaults.yml`
+Below, you can see an example `project-defaults` file that connect to an H2
+database.
 
 [source,yaml]
 ----

--- a/docs/howto/create-a-hollow-jar/index.adoc
+++ b/docs/howto/create-a-hollow-jar/index.adoc
@@ -1,18 +1,19 @@
-[#create_a_hollow_jar]
-= Create a hollow jar
+[#creating-a-hollow-jar]
+= Creating a hollow JAR
 
-One method of packaging an application for execution
-with WildFly Swarm is as a <<hollow_jar>>.
+The xref:hollow-jar[hollow JAR] is one method of packaging an application for
+execution with WildFly Swarm.
 
 .Prerequisites
 
-* A _Maven_-based application with a `pom.xml`
+* A Maven-based application with a `pom.xml` file.
 
 .Procedure
 
-. Add the `wildfly-swarm-maven-plugin` to your `pom.xml` by adding a `<plugin>` block,
-  with an `<execution>` specifying the `package` goal.  Additionally in the `<configuration>`
-  for the plugin, specify the value of `true` for the property `hollow`:
+. Add the `wildfly-swarm-maven-plugin` to your `pom.xml` in a `<plugin>` block,
+  with an `<execution>` specifying the `package` goal.
+  In addition to that, put `true` in the `hollow` property of the
+  `<configuration>` element:
 +
 [source,xml]
 ----
@@ -23,16 +24,23 @@ include::pom.xml[tag=plugin,indent=2]
 
 . Perform a normal Maven build:
 +
-    $ mvn package
+[source]
+----
+$ mvn package
+----
 
-. Run your uberjar:
+. Execute the hollow JAR:
 +
-Execute the resulting `-hollowswarm.jar` using `java -jar` and pass your
-normal `.war` file as the first argument:
-+    
-    $ java -jar ./target/myapp-hollowswarm.jar ./target/myapp.war
+Execute the resulting `-hollowswarm.jar` file using the Java binary and pass
+the `.war` file with your application as the first argument:
++
+[source]
+----
+$ java -jar ./target/myapp-hollowswarm.jar ./target/myapp.war
+----
 
 .Related Information
 
-* <<hollow_jar>>
-* <<create_an_uberjar>> 
+* xref:hollow-jar[]
+* xref:creating-an-uberjar[]
+

--- a/docs/howto/create-an-uberjar/index.adoc
+++ b/docs/howto/create-an-uberjar/index.adoc
@@ -1,16 +1,16 @@
-[#create_an_uberjar]
-= Create an Uberjar
+[#creating-an-uberjar]
+= Creating an Uberjar
 
 One method of packaging an application for execution
 with WildFly Swarm is as an _uberjar_. 
 
 .Prerequisites
 
-* A _Maven_-based application with a `pom.xml`
+* A Maven-based application with a `pom.xml` file.
 
 .Procedure
 
-. Add the `wildfly-swarm-maven-plugin` to your `pom.xml` by adding a `<plugin>` block,
+. Add the `wildfly-swarm-maven-plugin` to your `pom.xml` in a `<plugin>` block,
   with an `<execution>` specifying the `package` goal.
 
 [source,xml]
@@ -23,12 +23,19 @@ include::pom.xml[tag=plugin,indent=2]
 [start=2]
 . Perform a normal Maven build:
 
-    $ mvn package
+[source]
+----
+$ mvn package
+----
 
-. Run your uberjar:
-    
-    $ java -jar ./target/myapp-swarm.jar
+. Execute the resulting uberjar:
+
+[source]
+----
+$ java -jar ./target/myapp-swarm.jar
+----
 
 .Related Information
 
-* Create a hollow jar
+* xref:creating-a-hollow-jar[]
+

--- a/docs/howto/test-in-container/index.adoc
+++ b/docs/howto/test-in-container/index.adoc
@@ -1,26 +1,19 @@
-[#test-in-container]
-= How to test in-container
+[#testing-in-a-container]
+= Testing in a container
 
-Using *Arquillian*, we have the capability of injecting
-unit tests into a running application.  This allows us
-to peel back the covers and peek inside to ensure that
-the correct things are occurring.
-
-Arquillian has existed for quite a while, and WildFly Swarm
-has simply created an adapter and some useful annotations to
-make Arquillian-based testing work well with WildFly Swarm
-applications.
+Using Arquillian, you have the capability of injecting unit tests into a
+running application. This allows you to verify your application is behaving
+correctly. There is an adapter for WildFly Swarm that makes Arquillian-based
+testing work well with WildFly Swarm&ndash;based applications.
 
 .Prerequisites
 
-* A _Maven_-based project.
+* A Maven-based application with a `pom.xml` file.
 
 .Procedure
 
-. To use the WildFly Swarm Arquillian integrations, you first
-include the WildFly Swarm BOM as described in <<use-a-bom>>,
-and then reference the `org.wildfly.swarm:arquillian` artifact with
-a `<scope>` of `test`:
+. Include the WildFly Swarm BOM as described in xref:using-a-bom[]. For
+example, `bom-all`:
 +
 [source,xml]
 ----
@@ -30,6 +23,8 @@ include::pom.xml[tag=bom,indent=4]
   </dependencies>
 </dependencyManagement>
 ----
+. Reference the `org.wildfly.swarm:arquillian` artifact in your `pom.xml` file
+with the `<scope>` set to `test`:
 +
 [source,xml]
 ----
@@ -38,105 +33,106 @@ include::pom.xml[tag=arquillian,indent=2]
 </dependencies>
 ----
 
-. Write your Application
+. Create your Application.
 +
-You construct your application like normal, including using
-any default `project-defaults.yml` you need to configure bits of
-it.
+Write your application as you normally would; use any default
+`project-defaults.yml` files you need to configure it.
 +
 [source,yml]
 ----
 include::src/main/resources/project-defaults.yml[]
 ----
 
-. Create a test class
+. Create a test class.
 +
-Creating an Arquillian test before WildFly Swarm generally involved
+NOTE: Creating an Arquillian test before WildFly Swarm existed usually involved
 programatically creating `Archive` due to the fact that applications
-were larger, and the desire was to test a single component in isolation.
+were larger, and the aim was to test a single component in isolation.
 +
 [source,java]
 ----
 include::src/test/java/org/wildfly/swarm/howto/incontainer/InContainerTest.java[tag=classdef,indent=0]
 ----
 
-. Create a deployment
+. Create a deployment.
 +
-In a world of microservices, this tends to not be the case, and the entire
-"application" represents one small microservice component.
-+
-The `@DefaultDeployment` annotation has been provided to automatically
+--
+In the context of microservices, the entire application represents one small
+microservice component.
+
+Use the `@DefaultDeployment` annotation to automatically
 create the deployment of the entire application. The `@DefaultDeployment`
-annotation defaults to creating a `.war`, which is not applicable in 
-this case, since Undertow is not involved.
-+
-It it applied at the class level of your typical JUnit test, along
-with the usual `@RunWith(Arquillian.class)` annotation:
-+
+annotation defaults to creating a `.war` file, which is not applicable in
+this case because Undertow is not involved in this process.
+
+Apply the `@DefaultDeployment` annotation at the class level of a JUnit test,
+along with the `@RunWith(Arquillian.class)` annotation:
+
 [source,java]
 ----
 include::src/test/java/org/wildfly/swarm/howto/incontainer/InContainerTest.java[tag=prolog,indent=0]
 ----
-+
-Using the `@DefaultDeployment` annotation provided by WildFly Swarm's
-Arquillian integration means you should *not* use the usual Arquillian
-`@Deployment` annotation on a static method returning an `Archive`.
-+
-The `@DefaultDeployment` annotation looks at the package of the test:
-+
+
+Using the `@DefaultDeployment` annotation provided by Arquillian integration
+with WildFly Swarm means you should _not_ use the Arquillian `@Deployment`
+annotation on static methods that return an `Archive`.
+
+The `@DefaultDeployment` annotation inspects the package of the test:
+
 [source,java]
 ----
 include::src/test/java/org/wildfly/swarm/howto/incontainer/InContainerTest.java[tag=package,indent=0]
 ----
-+
-From that package, it uses heuristics to include all of your other application classes
-residing in that package or deeper within the Java packaging hierarchy.
-+
-While this allows for creating tests that only create a "default deployment" for sub-packages
-of your application, it does also prevent you from placing tests in an unrelated
-package, such as:
-+
+
+From the package, it uses heuristics to include all of your other application
+classes in the same package or deeper in the Java packaging hierarchy.
+
+Even though using the `@DefaultDeployment` annotation allows you to write tests
+that only create a _default deployment_ for sub-packages of your application,
+it also prevents you from placing tests in an unrelated package, for example:
+
 [source,java]
 ----
 package org.mycorp.myapp.test;
 ----
+--
 
-. Write your test code
+. Write your test code.
 +
-Now, simply write your normal Arquillian-type of test, including using Arquillian
-facilities to gain access to internal running components.
-+
-Here, we use Arquillian to inject the `InitialContext` of the running application
-into an instance member of our test-case:
-+
+--
+Write an Arquillian-type of test as you normally would, including using
+Arquillian facilities to gain access to internal running components.
+
+In the example below, Arquillian is used to inject the `InitialContext` of the
+running application into an instance member of the test case:
+
 [source,java]
 ----
 include::src/test/java/org/wildfly/swarm/howto/incontainer/InContainerTest.java[tag=arquillian-resource,indent=0]
 ----
-+
-Then our test method itself can use that `InitialContext` in order to ensure
-the datasource we configured using `project-defaults.yml` is actually live and
-available:
-+
+
+That means the test method itself can use that `InitialContext` to ensure the
+Datasource you configured using `project-defaults.yml` is live and available:
+
 [source,java]
 ----
 include::src/test/java/org/wildfly/swarm/howto/incontainer/InContainerTest.java[tag=test,indent=0]
 ----
+--
 
-. Run your test
+. Run the tests.
 +
-Since Arquillian is simply an integration with JUnit, you can run your test
-by using Maven or your IDE:
+Because Arquillian provides an integration with JUnit, you can execute your
+test classes using Maven or your IDE:
 +
 [source,shell]
 ----
 $ mvn install
 ----
 +
-In many IDEs, simply find your test-class, right-click and select `Run` to execute the
-test.
+NOTE: In many IDEs, execute a test class by right-clicking it and selecting `Run`.
 
 .Related Information
 
-* <<use-a-bom>>
+* xref:using-a-bom[]
 

--- a/docs/howto/use-a-bom/index.adoc
+++ b/docs/howto/use-a-bom/index.adoc
@@ -1,98 +1,73 @@
-[#use-a-bom]
-= How to use a BOM
+[#using-a-bom]
+= Using a BOM
 
-If you want to explicitly enumerate the WildFly Swarm
+To explicitly specify the WildFly Swarm
 fractions your application uses, instead of relying
-on auto-detection, the project includes a set of 
-BOMs (bill of materials) which you may use to avoid
+on auto-detection, WildFly Swarm includes a set of
+BOMs (bill of materials) which you can use instead of
 having to track and update Maven artifact versions
 in several places.
 
 ifndef::product[]
+== Different types of BOMs
 
-## Different types of BOMs
-
-WildFly Swarm is described as "just enough app-server",
-which means it's composed of lots of pieces.  Your application
+WildFly Swarm is described as _just enough app-server,_
+which means it comprises of multiple pieces.  Your application
 includes only the pieces it needs.
 
-Over time, some of these pieces have reached "stable" status,
-while some are decidedly "unstable" or even "experimental". 
-To help segregate the stable from the not-as-stable, different
-Maven BOMs may be used.  
+Over time, some of these pieces reach the _stable_ status,
+while some are classified as _unstable_ or _experimental._
+To help separate the stable pieces from the less stable ones,
+the following Maven BOMs can be used:
 
-* `bom-all`
+bom-all:: All fractions: stable, unstable, experimental, and
+even deprecated.
 
-The `bom-all` BOM includes everything, soup-to-nuts. Anything
-that is stable, unstable, experimental, or even deprecated is
-included.
+bom-deprecated:: Fractions that have been deprecated.
 
-* `bom-deprecated`
+bom-experimental:: Fractions that are considered experimental, which
+means they can disappear or radically change between releases.
 
-The `bom-deprecated` BOM includes only those fractions that
-have been deprecated.
+bom-unstable:: Fractions that do not change as often as the experimental ones.
+However, unstable fractions can still change their behavior or contain bugs,
+even dangerous ones.
 
-* `bom-experimental`
-
-The `bom-experimental` BOM includes only those fractions that
-are considered experimental. They may disappear or radically change
-between releases.
-
-* `bom-unstable`
-
-The `bom-unstable` BOM includes fractions that are better than
-experimental, but may still be subject to large changes in their
-behaviour, or may contain dangerous or annoying bugs.
-
-* `bom-stable` or `bom`
-
-The `bom-stable` BOM (which is aliased to just `bom` also) contains
-those known-good fractions that are recommended for daily use.
-
+bom-stable or bom:: Fractions recommended for daily use.
 endif::[]
 
 ifdef::product[]
+== Available BOMs
 
-* The `bom` artifact
+You can use the following Maven BOMs:
 
-The artifact named `bom` defines all fractions available within
-the product.
+bom:: All fractions available in the product.
 
-* The `bom-certified` artifact
-
-The artifact named `bom-certified` defines all _community_ fractions
-that have been certified against the product. Any fraction used from
-`bom-certified` is unsupported.
-
+bom-certified:: All _community_ fractions that have been certified against the
+product. Any fraction used from `bom-certified` is unsupported.
 endif::[]
 
 .Prerequisites
 
-* A _Maven_-based project with a `pom.xml`
+* Your application as a Maven-based project with a `pom.xml` file.
 
 .Procedure
 
-. Include a `bom` artifact in your `pom.xml`
+. Include a `bom` artifact in your `pom.xml`.
 +
-We usually suggest tracking the current version of WildFly Swarm
-through a property in your `pom.xml`
-+
+--
+Tracking the current version of WildFly Swarm through a property in your
+`pom.xml` is recommended.
+
 [source,xml]
 ----
 <properties>
 include::pom.xml[tag=property,indent=2]
 </properties>
 ----
-+
-In all usage of BOMs with Maven, they are _imported_
-into your project through the `<dependencyManagement>`
-section.
-+
-You must specify the `<type>pom</type>` and `<scope>import</scope>`.
-+
-In the example below, we import the `bom` artifact to ensure that
-only stable fractions are available.
-+
+
+Import BOMs in the `<dependencyManagement>` section. Specify the
+`<type>pom</type>` and `<scope>import</scope>`.
+
 [source,xml]
 ----
 <dependencyManagement>
@@ -101,12 +76,15 @@ include::pom.xml[tag=bom-dependency,indent=4]
   </dependencies>
 </dependencyManagement>
 ----
-+
-ifndef::product[] 
-If we also wanted to experiment with some unstable fractions
-in addition to the stable ones, we would uncomment the `<dependency>`
-for `bom-unstable`:
-+
+
+In the example above, the `bom` artifact is imported to ensure that
+only stable fractions are available.
+
+
+ifndef::product[]
+If you want to experiment with some unstable fractions in addition to the
+stable ones, uncomment the `<dependency>` for `bom-unstable`:
+
 [source,xml]
 ----
 <dependencyManagement>
@@ -116,59 +94,57 @@ include::pom.xml[tag=bom-unstable-dependency,indent=4]
   </dependencies>
 </dependencyManagement>
 ----
-+
+
 Remember, each flavor of `bom`, with the exception of `bom-all`
 contains only the type of fractions indicated.  This allows mixing
 and matching the combination of fraction stability that you want
-with fine granularity.  If you want both stable and unstable, you
-would need to include `bom-stable` (or simply `bom`, which is the same
-as `bom-stable`) *and* `bom-unstable`.
+with fine granularity. If you want both stable and unstable, you
+would need to include both `bom-stable` (or `bom`) and `bom-unstable`.
 endif::[]
 
-. Include WildFly Swarm dependencies
-+
-Once you've used the `<dependencyManagement>` section to import
-one or more WildFly Swarm BOMs, your application still has *no* 
-dependencies on WildFly Swarm artifacts.  All that has been accomplished
-is:
-+
-* Providing version-management for any WildFly Swarm artifacts you
+By including the BOMs of your choice in the `<dependencyManagement>` section,
+you have:
+
+* Provided version-management for any WildFly Swarm artifacts you
 subsequently *choose* to use.
-* Providing support to your IDE for auto-completing known artifacts
-while you edit your own `pom.xml`
+* Provided support to your IDE for auto-completing known artifacts
+when you edit your the `pom.xml` file of your application.
+--
+
+. Include WildFly Swarm dependencies.
 +
-That being said, now you need to actually include some WildFly Swarm
-artifact dependencies, based upon the capabilities your application
-requires.
-+
-This is done through normal Maven `<dependency>` elements.
-+
-Here we include explicit dependencies on the `jaxrs` and `datasources`
-fractions, which will provide transitive inclusion of others, such
-as `undertow`.
-+
+--
+Even though you imported the WildFly Swarm BOMs in the `<dependencyManagement>`
+section, your application still has no dependencies on WildFly Swarm
+artifacts.
+
+To include WildFly Swarm artifact dependencies based on the capabilities your
+application, enter the relevant artifacts as `<dependency>` elements:
+
+NOTE: You do not have to specify the version of the artifacts because the BOM
+imported in `<dependencyManagement>` handles that.
+
 [source,xml]
 ----
 <dependencies>
 include::pom.xml[tag=fraction-dependencies,indent=2]
 </dependencies>
 ----
-+
-Notice, you have not had to specify the usual `<version>` element
-for these `<dependency>` blocks, because the BOM you imported
-via `<dependencyManagement>` handles that portion for you.
 
-## Caveats
+In the example above, we include explicit dependencies on the `jaxrs` and
+`datasources` fractions, which will provide transitive inclusion of others,
+for example `undertow`.
+--
 
-One short-coming of a Maven BOM import is that it does not
-handle `<pluginManagement>`-level configuration.  When you
-use the WildFly Swarm Maven Plugin, you still must specify
-the version of the plugin to use.
+== Caveats
 
-Therefore, since you've used a property within your `pom.xml`
-you can still easily ensure that your plugin usage matches
-the release of WildFly Swarm that you're targetting with
-the BOM import.
+One shortcoming of importing a Maven BOM import is that it does not
+handle the configuration on the level of `<pluginManagement>`. When you use the
+WildFly Swarm Maven Plugin, you must specify the version of the plugin to use.
+
+Thanks to the property you use in your `pom.xml` file, you can easily ensure
+that your plugin usage matches the release of WildFly Swarm that you are
+targeting with the BOM import.
 
 [source,xml]
 ----
@@ -182,5 +158,5 @@ include::pom.xml[tag=plugin,indent=4]
 
 .Related Information
 
-* <<create_an_uberjar>>
+* xref:creating-an-uberjar[]
 


### PR DESCRIPTION
Rendered docs are in my [private space](
http://download.eng.brq.redhat.com/scratch/tradej/wf-swarm/doc-improvement-27/generated-docs/).

Notes:

* The scope is much extended as opposed to the original PR. This is mostly due to overlap with #651 and the fact that I was already editing the files. After this is merged, I intend to keep strictly to the scope of PRs. 
* Anchor IDs now follow the convention that was merged to the modular docs today (hyphens everywhere)
* _Creating a datasource_ was split into three modules. The `index.adoc` file is essentially an assembly now. [readability, modularity]
* All headings are now in a gerund form [convention]
* Removed most of the emphasis [convention]
* I rewrote many sentences from scratch, please check for factual correctness. Thanks.